### PR TITLE
Change string array to dictionary

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ export interface ParserOptions {
 
 export interface ProxyConfig {
   target?: string;
-  headers?: string[];
+  headers?: Record<string, string>;
 }
 
 export interface FetchOptions {
@@ -51,7 +51,7 @@ export interface FetchOptions {
    * list of request headers
    * default: null
    */
-  headers?: string[];
+  headers?: Record<string, string>;
   /**
    * the values to configure proxy
    * default: null


### PR DESCRIPTION
headers in js require an object, but this type is set to a string array. 

Using a Record<string, string> will make this act like a dictionary.