### PR TITLE
Fix ParserOptions typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,22 +23,22 @@ export interface ParserOptions {
    * to estimate time to read.
    * Default: 300
    */
-  wordsPerMinute: number
+  wordsPerMinute?: number
   /**
    * max num of chars generated for description
    * Default: 210
    */
-  descriptionTruncateLen: number
+  descriptionTruncateLen?: number
   /**
    * min num of chars required for description
    * Default: 180
    */
-  descriptionLengthThreshold: number
+  descriptionLengthThreshold?: number
   /**
    * min num of chars required for content
    * Default: 200
    */
-  contentLengthThreshold: number
+  contentLengthThreshold?: number
 }
 
 export interface ProxyConfig {


### PR DESCRIPTION
From the prod code, the options fields are all options: https://github.com/extractus/article-extractor/blob/b9cb636e18b6bd5c7a18f614eed19f8546ab986a/src/utils/parseFromHtml.js#L50-L55