### PR TITLE
Feat: extract pagetype from og:type or ld+json

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,7 @@ export interface ArticleData {
   source?: string;
   published?: string;
   ttr?: number;
+  type?: string;
 }
 
 export function extract(input: string, parserOptions?: ParserOptions, fetchOptions?: FetchOptions): Promise<ArticleData|null>;

--- a/src/utils/extractLdSchema.js
+++ b/src/utils/extractLdSchema.js
@@ -1,0 +1,71 @@
+const typeSchemas = [
+  'aboutpage',
+  'checkoutpage',
+  'collectionpage',
+  'contactpage',
+  'faqpage',
+  'itempage',
+  'medicalwebpage',
+  'profilepage',
+  'qapage',
+  'realestatelisting',
+  'searchresultspage',
+  'webpage',
+  'website',
+  'article',
+  'advertisercontentarticle',
+  'newsarticle',
+  'analysisnewsarticle',
+  'askpublicnewsarticle',
+  'backgroundnewsarticle',
+  'opinionnewsarticle',
+  'reportagenewsarticle',
+  'reviewnewsarticle',
+  'report',
+  'satiricalarticle',
+  'scholarlyarticle',
+  'medicalscholarlyarticle',
+]
+
+const attributeLists = {
+  description: 'description',
+  image: 'image',
+  author: 'author',
+  published: 'datePublished',
+  type: '@type',
+}
+
+/**
+ * Parses JSON-LD data from a document and populates an entry object.
+ * Only populates if the original entry object is empty or undefined.
+ *
+ * @param {Document} document - The HTML Document
+ * @param {Object} entry - The entry object to merge/populate with JSON-LD.
+ * @returns {Object} The entry object after being merged/populated with data.
+ */
+export default (document, entry) => {
+  const ldSchema = document.querySelector('script[type="application/ld+json"]')?.textContent
+
+  if (!ldSchema) {
+    return entry
+  }
+
+  const ldJson = JSON.parse(ldSchema)
+  Object.entries(attributeLists).forEach(([key, attr]) => {
+    if ((typeof entry[key] === 'undefined' || entry[key] === '') && ldJson[attr]) {
+      if (key === 'type' && typeof ldJson[attr] === 'string') {
+        return entry[key] = typeSchemas.includes(ldJson[attr].toLowerCase()) ? ldJson[attr].toLowerCase() : ''
+      }
+
+      if (typeof ldJson[attr] === 'string') {
+        return entry[key] = ldJson[attr].toLowerCase()
+      }
+
+      if (Array.isArray(ldJson[attr]) && typeof ldJson[attr][0] === 'string') {
+        return entry[key] = ldJson[attr][0].toLowerCase()
+      }
+    }
+  })
+
+  return entry
+}

--- a/src/utils/extractMetaData.test.js
+++ b/src/utils/extractMetaData.test.js
@@ -7,10 +7,19 @@ import { isObject, hasProperty } from 'bellajs'
 
 import extractMetaData from './extractMetaData.js'
 
-const keys = 'url shortlink amphtml canonical title description image author source published favicon'.split(' ')
+const keys = 'url shortlink amphtml canonical title description image author source published favicon type'.split(' ')
 
 test('test extractMetaData(good content)', async () => {
   const html = readFileSync('./test-data/regular-article.html', 'utf8')
+  const result = extractMetaData(html)
+  expect(isObject(result)).toBe(true)
+  keys.forEach((k) => {
+    expect(hasProperty(result, k)).toBe(true)
+  })
+})
+
+test('test extractMetaData(json ld schema content)', async () => {
+  const html = readFileSync('./test-data/regular-article-json-ld.html', 'utf8')
   const result = extractMetaData(html)
   expect(isObject(result)).toBe(true)
   keys.forEach((k) => {

--- a/src/utils/parseFromHtml.js
+++ b/src/utils/parseFromHtml.js
@@ -45,6 +45,7 @@ export default async (inputHtml, inputUrl = '', parserOptions = {}) => {
     author,
     published,
     favicon: metaFav,
+    type,
   } = meta
 
   const {
@@ -127,5 +128,6 @@ export default async (inputHtml, inputUrl = '', parserOptions = {}) => {
     source: getDomain(bestUrl),
     published,
     ttr: getTimeToRead(textContent, wordsPerMinute),
+    type,
   }
 }

--- a/test-data/regular-article-json-ld.html
+++ b/test-data/regular-article-json-ld.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Article title here - ArticleParser</title>
+    <meta name="keywords" content="alpha, beta, gamma">
+    <meta name="twitter:site" content="@ArticleParser">
+    <meta name="twitter:url" content="https://somewhere.com/path/to/article-title-here">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:creator" content="@alice">
+    <meta property="og:title" content="Article title here">
+    <meta property="og:url" content="https://somewhere.com/path/to/article-title-here">
+
+
+<script type="application/ld+json">
+    { "@context": "https://schema.org",
+      "@type": "Article",
+      "author": "Alice",
+      "image": [
+        "https://somewhere.com/path/to/image.jpg",
+        "https://somewhere.com/path/to/image2.jpg",
+        "https://somewhere.com/path/to/image3.jpg"
+      ],
+      "datePublished": "23\/01\/2014",
+      "dateCreated": "23\/01\/2014",
+      "description": "Navigation here Few can name a rational peach that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs."
+    }
+  </script>
+
+    <link rel="stylesheet" href="/path/to/cssfile.css">
+    <link rel="canonical" href="https://somewhere.com/another/path/to/article-title-here">
+    <link rel="amphtml" href="https://m.somewhere.com/another/path/to/article-title-here.amp">
+    <link rel="shortlink" href="https://sw.re/419283">
+    <link rel="icon" href="https://somewhere.com/favicon.ico">
+
+    <link rel="alternate" title="ArticleParser" type="application/atom+xml" href="https://somewhere.com/atom.xml">
+
+    <link rel="manifest" href="/manifest.json">
+  </head>
+  <body>
+    <header>Page header here</header>
+    <main>
+      <section>
+        <nav>Navigation here</nav>
+      </section>
+      <section>
+        <h1>Article title here</h1>
+        <article>
+          <div class="contentdetail">Few can name a <a href="https://otherwhere.com/descriptions/rational-peach">rational peach</a> that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs. Some posit the enchanting tiger to be less than confident. The literature would have us believe that an impartial turtle is not but a hippopotamus. Unfortunately, that is wrong; on the contrary, those cows are nothing more than pandas! The chicken is a shark; A turtle can hardly be considered a kind horse without also being a pomegranate. Zebras are witty persimmons.</div>
+          <p class="contentdetail">
+            Those cheetahs are nothing more than dogs. A <a href="/dict/watermelon">watermelon</a> is an exuberant kangaroo. An octopus is the tangerine of a grapes? The cherry is a shark. Recent controversy aside, they were lost without the cheerful plum that composed their fox. As far as we can estimate, one cannot separate camels from dynamic hamsters. Those tigers are nothing more than cows! A cow is a squirrel from the right perspective. Their banana was, in this moment, a helpful bear.</p>
+          <p>The first fair dog is, in its own way, a lemon.</p>
+          <address>4746 Kelly Drive, West Virginia</address>
+          <img src="./orange.png" style="border: solid 1px #000">
+        </article>
+      </section>
+      <section class="sidebar-widget">
+        <widget>Some widget here</widget>
+        <widget>Some widget here</widget>
+      </section>
+    </main>
+    <footer>Page footer here</footer>
+  </body>
+</html>


### PR DESCRIPTION
This pull request addresses the issue https://github.com/extractus/article-extractor/issues/373 and includes several improvements:

1 - Refactoring of extractMetaData to avoid repetition and enhance maintainability.
2 - Adds extraction of JSON+LD Schema for certain parameters such as description, image, author, published and type in case they are not found by extractMetaData. This provides an additional extraction option for these parameters.
3 - Opens up the possibility to enhance and expand the extraction of other parameters through the JSON+LD Schema.
4 - Adds a test for extractLDSchema.
5 - Adds the OG:TYPE meta tag based on https://schema.org/docs/full.html (returns only types related to articles, blogs, and websites).

**No external dependencies were used, only the logic from the article-extractor itself.**