### PR TITLE
chore: Improvements in handling LD+JSON data

### DIFF
--- a/test-data/regular-article-json-ld.html
+++ b/test-data/regular-article-json-ld.html
@@ -22,6 +22,9 @@
         "https://somewhere.com/path/to/image2.jpg",
         "https://somewhere.com/path/to/image3.jpg"
       ],
+      "keywords": "keyword1, keyword2, keyword3",
+      "keywords_with_line_breaks": "keyword1, keyword2,
+      keyword3",
       "datePublished": "23\/01\/2014",
       "dateCreated": "23\/01\/2014",
       "description": "Navigation here Few can name a rational peach that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs."


### PR DESCRIPTION
- Captures all ld+json tags on the site. Previously, it only captured the first one, which resulted in empty captures depending on the type.
- Resolves the issue of improper JSON formatting regarding line breaks in inappropriate places, causing problems in data capture.
- Simplifies the logic of value assignment and better performance.

**A real example:**

In the url: https://natelinha.uol.com.br/famosos/2024/10/13/esposa-de-rodrigo-faro-vera-viel-compartilha-rotina-no-hospital-apos-cirurgia-217809.php the extraction of the date return empty because the html only has ld+json metadata for this info.

This is fixed with this PR.

For future: I'm thinking to do a more complex logic for ld+json extraction. There is sites for example (like the above one) that include a real author name for the post and not the `@sitename` like in `og:author`.