### PR TITLE
Fix: Fatal error on empty @type string in ld+json verification.

### DIFF
--- a/src/utils/extractLdSchema.js
+++ b/src/utils/extractLdSchema.js
@@ -56,7 +56,7 @@ export default (document, entry) => {
 
   ldSchemas.forEach(ldSchema => {
     const ldJson = parseJson(ldSchema.textContent.replace(/[\n\r\t]/g, ''))
-    const isAllowedLdJsonType = typeSchemas.includes(ldJson['@type'].toLowerCase())
+    const isAllowedLdJsonType = typeSchemas.includes(ldJson['@type']?.toLowerCase())
 
     if (ldJson && isAllowedLdJsonType) {
       Object.entries(attributeLists).forEach(([key, attr]) => {

--- a/test-data/regular-article-json-ld.html
+++ b/test-data/regular-article-json-ld.html
@@ -12,6 +12,27 @@
     <meta property="og:title" content="Article title here">
     <meta property="og:url" content="https://somewhere.com/path/to/article-title-here">
 
+<script type="application/ld+json">
+    [{ "@context": "https://schema.org",
+      "@type": "SomeRandomType",
+      "author": "Alice",
+      "keywords": "keyword1, keyword2, keyword3",
+      "keywords_with_line_breaks": "keyword1, keyword2,
+      keyword3",
+      "datePublished": "23\/01\/2014",
+      "dateCreated": "23\/01\/2014"
+    },
+    { "@context": "https://schema.org",
+      "@type": "AnotherRandomType",
+      "author": {
+        "@type": "Person",
+        "name": "Alice"
+      },
+      "keywords": "keyword1, keyword2, keyword3",
+      "keywords_with_line_breaks": "keyword1, keyword2,
+      keyword3"
+    }]
+  </script>
 
 <script type="application/ld+json">
     { "@context": "https://schema.org",


### PR DESCRIPTION
Urgent: Sorry, but there was a problem passing the @type value in the ld+json verification that was causing a fatal error. Currently, we only check a certain level and configuration of ld+json.

The issue is that some sites unify all entries into a single ld+json script tag and come as an array without the @type at the top level.

This has been resolved in this version. I am working to ensure that this functionality now supports multiple levels of LD Schema context.

I added a test example to avoid this in future releases.

Big sorry for that.