### PR TITLE
Improvements to find dates

### DIFF
--- a/src/utils/extractMetaData.js
+++ b/src/utils/extractMetaData.js
@@ -2,6 +2,7 @@
 
 import { DOMParser } from 'linkedom'
 import extractLdSchema from './extractLdSchema.js'
+import findDate from './findDate.js'
 
 /**
  * @param {Element} node
@@ -143,5 +144,10 @@ export default (html) => {
   })
 
   const entries = extractLdSchema(doc, entry)
+
+  if (!entries.published) {
+    entries.published = findDate(doc)
+  }
+
   return entries
 }

--- a/src/utils/extractMetaData.test.js
+++ b/src/utils/extractMetaData.test.js
@@ -10,6 +10,12 @@ import extractMetaData from './extractMetaData.js'
 
 const keys = 'url shortlink amphtml canonical title description image author source published favicon type'.split(' ')
 
+function isDateString (date) {
+  if (typeof date !== 'string') return false
+  const d = new Date(date)
+  return !isNaN(d.getTime())
+}
+
 describe('test extractMetaData', () => {
   it('test extractMetaData(good content)', async () => {
     const html = readFileSync('./test-data/regular-article.html', 'utf8')
@@ -27,5 +33,25 @@ describe('test extractMetaData', () => {
     keys.forEach((k) => {
       assert.ok(hasProperty(result, k))
     })
+  })
+
+  it('test extractMetaData(find date)', async () => {
+    const html1 = readFileSync('./test-data/regular-article-date-time.html', 'utf8')
+    const html2 = readFileSync('./test-data/regular-article-date-itemprop.html', 'utf8')
+    const html3 = readFileSync('./test-data/regular-article-date-span.html', 'utf8')
+    const result1 = extractMetaData(html1)
+    const result2 = extractMetaData(html2)
+    const result3 = extractMetaData(html3)
+    assert.ok(isObject(result1))
+    assert.ok(isObject(result2))
+    assert.ok(isObject(result3))
+    keys.forEach((k) => {
+      assert.ok(hasProperty(result1, k))
+      assert.ok(hasProperty(result3, k))
+      assert.ok(hasProperty(result3, k))
+    })
+    assert.ok(isDateString(result1.published))
+    assert.ok(isDateString(result2.published))
+    assert.ok(isDateString(result3.published))
   })
 })

--- a/src/utils/findDate.js
+++ b/src/utils/findDate.js
@@ -1,0 +1,57 @@
+
+/**
+ * Convert date format to YYYY-MM-DD
+ *
+ * @param {string} dateString
+ * @returns {string} YYYY-MM-DD
+ */
+function convertDateFormat (dateString) {
+  const parts = dateString.split('/')
+  if (parts.length !== 3) return dateString
+
+  let year, month, day
+
+  if (parseInt(parts[0]) > 12) {
+    [day, month, year] = parts
+  } else {
+    [month, day, year] = parts
+  }
+
+  year = year.length === 2 ? '20' + year : year
+  return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T00:00:00`
+}
+
+/**
+ * Look for the publication date in the body of the content.
+ *
+ * @param {Document} document - The HTML Document
+ * @returns {string} The date string
+ */
+export default function (doc) {
+  const datePatterns = [
+    /\d{4}-\d{2}-\d{2}/,
+    /\d{1,2}\/\d{1,2}\/\d{2,4}/,
+  ]
+
+  const findDate = (element) => {
+    for (const pattern of datePatterns) {
+      const match = element.textContent.match(pattern)
+      if (match) return convertDateFormat(match[0])
+    }
+    return null
+  }
+
+  const priorityElements = doc.querySelectorAll('time, [datetime], [itemprop~=datePublished], [itemprop~=dateCreated]')
+  for (const el of priorityElements) {
+    const date = el.getAttribute('datetime') || el.getAttribute('content') || findDate(el)
+    if (date) return date
+  }
+
+  const secondaryElements = doc.querySelectorAll('p, span, div')
+  for (const el of secondaryElements) {
+    const date = findDate(el)
+    if (date) return date
+  }
+
+  return null
+}

--- a/test-data/regular-article-date-itemprop.html
+++ b/test-data/regular-article-date-itemprop.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Article title here - ArticleParser</title>
+    <meta name="author" content="Alice">
+    <meta name="description" content="Few words about this article">
+    <meta name="keywords" content="alpha, beta, gamma">
+    <meta name="twitter:site" content="@ArticleParser">
+    <meta name="twitter:url" content="https://somewhere.com/path/to/article-title-here">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="https://somewhere.com/path/to/image.jpg">
+    <meta name="twitter:creator" content="@alice">
+    <meta property="og:title" content="Article title here">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://somewhere.com/path/to/article-title-here">
+    <meta property="og:description" content="Navigation here Few can name a rational peach that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs.">
+    <meta property="og:image" content="https://somewhere.com/path/to/image.jpg">
+
+    <link rel="stylesheet" href="/path/to/cssfile.css">
+    <link rel="canonical" href="https://somewhere.com/another/path/to/article-title-here">
+    <link rel="amphtml" href="https://m.somewhere.com/another/path/to/article-title-here.amp">
+    <link rel="shortlink" href="https://sw.re/419283">
+    <link rel="icon" href="https://somewhere.com/favicon.ico">
+
+    <link rel="alternate" title="ArticleParser" type="application/atom+xml" href="https://somewhere.com/atom.xml">
+
+    <link rel="manifest" href="/manifest.json">
+  </head>
+  <body>
+    <header>Page header here</header>
+    <main>
+      <section>
+        <nav>Navigation here</nav>
+      </section>
+      <section>
+        <h1>Article title here</h1>
+        <article>
+          <div itemprop="datePublished" datetime='2024-10-16T07:33+03:00' class='published'> Published 11/09/2024 07h33min</div>
+
+          <div class="contentdetail">Few can name a <a href="https://otherwhere.com/descriptions/rational-peach">rational peach</a> that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs. Some posit the enchanting tiger to be less than confident. The literature would have us believe that an impartial turtle is not but a hippopotamus. Unfortunately, that is wrong; on the contrary, those cows are nothing more than pandas! The chicken is a shark; A turtle can hardly be considered a kind horse without also being a pomegranate. Zebras are witty persimmons.</div>
+          <p class="contentdetail">
+            Those cheetahs are nothing more than dogs. A <a href="/dict/watermelon">watermelon</a> is an exuberant kangaroo. An octopus is the tangerine of a grapes? The cherry is a shark. Recent controversy aside, they were lost without the cheerful plum that composed their fox. As far as we can estimate, one cannot separate camels from dynamic hamsters. Those tigers are nothing more than cows! A cow is a squirrel from the right perspective. Their banana was, in this moment, a helpful bear.</p>
+          <p>The first fair dog is, in its own way, a lemon.</p>
+          <address>4746 Kelly Drive, West Virginia</address>
+          <img src="./orange.png" style="border: solid 1px #000">
+        </article>
+      </section>
+      <section class="sidebar-widget">
+        <widget>Some widget here</widget>
+        <widget>Some widget here</widget>
+      </section>
+    </main>
+    <footer>Page footer here</footer>
+  </body>
+</html>

--- a/test-data/regular-article-date-span.html
+++ b/test-data/regular-article-date-span.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Article title here - ArticleParser</title>
+    <meta name="author" content="Alice">
+    <meta name="description" content="Few words about this article">
+    <meta name="keywords" content="alpha, beta, gamma">
+    <meta name="twitter:site" content="@ArticleParser">
+    <meta name="twitter:url" content="https://somewhere.com/path/to/article-title-here">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="https://somewhere.com/path/to/image.jpg">
+    <meta name="twitter:creator" content="@alice">
+    <meta property="og:title" content="Article title here">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://somewhere.com/path/to/article-title-here">
+    <meta property="og:description" content="Navigation here Few can name a rational peach that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs.">
+    <meta property="og:image" content="https://somewhere.com/path/to/image.jpg">
+
+    <link rel="stylesheet" href="/path/to/cssfile.css">
+    <link rel="canonical" href="https://somewhere.com/another/path/to/article-title-here">
+    <link rel="amphtml" href="https://m.somewhere.com/another/path/to/article-title-here.amp">
+    <link rel="shortlink" href="https://sw.re/419283">
+    <link rel="icon" href="https://somewhere.com/favicon.ico">
+
+    <link rel="alternate" title="ArticleParser" type="application/atom+xml" href="https://somewhere.com/atom.xml">
+
+    <link rel="manifest" href="/manifest.json">
+  </head>
+  <body>
+    <header>Page header here</header>
+    <main>
+      <section>
+        <nav>Navigation here</nav>
+      </section>
+      <section>
+        <h1>Article title here</h1>
+        <article>
+          <span  class='published'> Published at 11/09/2024 07h33 am</span>
+
+          <div class="contentdetail">Few can name a <a href="https://otherwhere.com/descriptions/rational-peach">rational peach</a> that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs. Some posit the enchanting tiger to be less than confident. The literature would have us believe that an impartial turtle is not but a hippopotamus. Unfortunately, that is wrong; on the contrary, those cows are nothing more than pandas! The chicken is a shark; A turtle can hardly be considered a kind horse without also being a pomegranate. Zebras are witty persimmons.</div>
+          <p class="contentdetail">
+            Those cheetahs are nothing more than dogs. A <a href="/dict/watermelon">watermelon</a> is an exuberant kangaroo. An octopus is the tangerine of a grapes? The cherry is a shark. Recent controversy aside, they were lost without the cheerful plum that composed their fox. As far as we can estimate, one cannot separate camels from dynamic hamsters. Those tigers are nothing more than cows! A cow is a squirrel from the right perspective. Their banana was, in this moment, a helpful bear.</p>
+          <p>The first fair dog is, in its own way, a lemon.</p>
+          <address>4746 Kelly Drive, West Virginia</address>
+          <img src="./orange.png" style="border: solid 1px #000">
+        </article>
+      </section>
+      <section class="sidebar-widget">
+        <widget>Some widget here</widget>
+        <widget>Some widget here</widget>
+      </section>
+    </main>
+    <footer>Page footer here</footer>
+  </body>
+</html>

--- a/test-data/regular-article-date-time.html
+++ b/test-data/regular-article-date-time.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Article title here - ArticleParser</title>
+    <meta name="author" content="Alice">
+    <meta name="description" content="Few words about this article">
+    <meta name="keywords" content="alpha, beta, gamma">
+    <meta name="twitter:site" content="@ArticleParser">
+    <meta name="twitter:url" content="https://somewhere.com/path/to/article-title-here">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="https://somewhere.com/path/to/image.jpg">
+    <meta name="twitter:creator" content="@alice">
+    <meta property="og:title" content="Article title here">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://somewhere.com/path/to/article-title-here">
+    <meta property="og:description" content="Navigation here Few can name a rational peach that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs.">
+    <meta property="og:image" content="https://somewhere.com/path/to/image.jpg">
+
+    <link rel="stylesheet" href="/path/to/cssfile.css">
+    <link rel="canonical" href="https://somewhere.com/another/path/to/article-title-here">
+    <link rel="amphtml" href="https://m.somewhere.com/another/path/to/article-title-here.amp">
+    <link rel="shortlink" href="https://sw.re/419283">
+    <link rel="icon" href="https://somewhere.com/favicon.ico">
+
+    <link rel="alternate" title="ArticleParser" type="application/atom+xml" href="https://somewhere.com/atom.xml">
+
+    <link rel="manifest" href="/manifest.json">
+  </head>
+  <body>
+    <header>Page header here</header>
+    <main>
+      <section>
+        <nav>Navigation here</nav>
+      </section>
+      <section>
+        <h1>Article title here</h1>
+        <article>
+          <time datetime='2024-10-16T07:33+03:00' class='published'> Published 11/09/2024 07h33min</time>
+
+          <div class="contentdetail">Few can name a <a href="https://otherwhere.com/descriptions/rational-peach">rational peach</a> that isn't a conscientious goldfish! One cannot separate snakes from plucky pomegranates? Draped neatly on a hanger, the melons could be said to resemble knowledgeable pigs. Some posit the enchanting tiger to be less than confident. The literature would have us believe that an impartial turtle is not but a hippopotamus. Unfortunately, that is wrong; on the contrary, those cows are nothing more than pandas! The chicken is a shark; A turtle can hardly be considered a kind horse without also being a pomegranate. Zebras are witty persimmons.</div>
+          <p class="contentdetail">
+            Those cheetahs are nothing more than dogs. A <a href="/dict/watermelon">watermelon</a> is an exuberant kangaroo. An octopus is the tangerine of a grapes? The cherry is a shark. Recent controversy aside, they were lost without the cheerful plum that composed their fox. As far as we can estimate, one cannot separate camels from dynamic hamsters. Those tigers are nothing more than cows! A cow is a squirrel from the right perspective. Their banana was, in this moment, a helpful bear.</p>
+          <p>The first fair dog is, in its own way, a lemon.</p>
+          <address>4746 Kelly Drive, West Virginia</address>
+          <img src="./orange.png" style="border: solid 1px #000">
+        </article>
+      </section>
+      <section class="sidebar-widget">
+        <widget>Some widget here</widget>
+        <widget>Some widget here</widget>
+      </section>
+    </main>
+    <footer>Page footer here</footer>
+  </body>
+</html>


### PR DESCRIPTION
I was having trouble on some sites like: https://atual7.com/noticias/politica/2024/10/brandao-e-camarao-retomam-conversas-governador-pode-disputar-senado-em-2026-e-vice-camara/ to extract dates.

I created a function that searches the body of the content for publication dates if the date was not found in the meta tags.

New tests have been created.