### PR TITLE
fix: adjustment of poorly formatted ldjson error

### DIFF
--- a/src/utils/extractLdSchema.js
+++ b/src/utils/extractLdSchema.js
@@ -43,7 +43,7 @@ const parseJson = (text) => {
   try {
     return JSON.parse(text)
   } catch {
-    return null
+    return {}
   }
 }
 


### PR DESCRIPTION
This PR fixes the error: `"error": "Cannot read properties of null (reading '@type')"`

When the json is poorly formatted on the site (with quote errors, for example)

ex: https://www.antenorferreira.com/2020/03/nada-sentiria-ou-seria-quando-muito.html